### PR TITLE
Add local models

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 - **Context-Aware**: Automatically uses relevant context from your IPython session
 - **Rich Output**: Markdown-formatted responses with syntax highlighting
-- **Multiple AI Models**: Supports GPT-4o, Claude 3.5 Sonnet, and Gemini. Local models coming soon.
+- **Multiple AI Models**: Supports GPT-4o, Claude 3.5 Sonnet, Gemini and local models using ollama.
 - **Interactive Configuration**: Easy model switching and configuration through magic commands
 
 ## Installation
@@ -60,6 +60,9 @@ In [1]: %models
 ## Configuration
 
 Based on the model you want to use, either set `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY`, or both environment variables. You can also run `ipychat config` to configure `ipychat` interactively.
+
+### Local models
+To use local models using `ollama` ensure that your Ollama server is running and that you have pulled some models. You can use ollama list to check what is locally available.
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "openai>=1.0.0",
     "anthropic>=0.5.0",
     "google-generativeai>=0.8.3",
+    "ollama>=0.4",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ipychat"
-version = "0.2.1"
+version = "0.2.2"
 description = "The AI IPython"
 readme = "README.md"
 authors = [{name = "Vinayak Mehta", email = "vmehta94@gmail.com"}]

--- a/src/ipychat/config.py
+++ b/src/ipychat/config.py
@@ -29,6 +29,7 @@ def get_default_config() -> Dict[str, Any]:
         },
         "anthropic": {"api_key": ""},
         "google": {"api_key": ""},
+        "local": {"api_key": "not-set"},
     }
 
     return DEFAULT_CONFIG

--- a/src/ipychat/config.py
+++ b/src/ipychat/config.py
@@ -29,7 +29,11 @@ def get_default_config() -> Dict[str, Any]:
         },
         "anthropic": {"api_key": ""},
         "google": {"api_key": ""},
-        "local": {"api_key": "not-set"},
+        "local": {
+            "api_key": "not-set",
+            "num_ctx": None,
+            "temperature": None,
+        },
     }
 
     return DEFAULT_CONFIG

--- a/src/ipychat/models.py
+++ b/src/ipychat/models.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 from .config import load_config
+import ollama
 
 
 @dataclass
@@ -20,6 +21,17 @@ AVAILABLE_MODELS = [
     ModelConfig("gemini-1.5-flash", "google", default_temperature=0.7),
 ]
 
+def get_ollama_models():
+    try:
+        models = ollama.list()
+        ollama_models = [ModelConfig(m.model, "local") for m in models.models]
+    except Exception as ex:
+        # This means ollama is not installed.
+        return []
+    return ollama_models
+
+ollama_models = get_ollama_models()
+AVAILABLE_MODELS.extend(ollama_models)
 
 def get_models_by_provider(provider: str) -> List[ModelConfig]:
     return [model for model in AVAILABLE_MODELS if model.provider == provider]

--- a/src/ipychat/models.py
+++ b/src/ipychat/models.py
@@ -21,6 +21,7 @@ AVAILABLE_MODELS = [
     ModelConfig("gemini-1.5-flash", "google", default_temperature=0.7),
 ]
 
+
 def get_ollama_models():
     try:
         models = ollama.list()
@@ -30,8 +31,10 @@ def get_ollama_models():
         return []
     return ollama_models
 
+
 ollama_models = get_ollama_models()
 AVAILABLE_MODELS.extend(ollama_models)
+
 
 def get_models_by_provider(provider: str) -> List[ModelConfig]:
     return [model for model in AVAILABLE_MODELS if model.provider == provider]

--- a/src/ipychat/models.py
+++ b/src/ipychat/models.py
@@ -19,6 +19,9 @@ AVAILABLE_MODELS = [
     ModelConfig("gpt-4o", "openai", default_max_tokens=2000, default_temperature=0.7),
     ModelConfig("claude-3-5-sonnet-20241022", "anthropic"),
     ModelConfig("gemini-1.5-flash", "google", default_temperature=0.7),
+    ModelConfig("gemini-2.0-flash", "google", default_temperature=0.7),
+    ModelConfig("gemini-2.5-pro-exp-03-25", "google", default_temperature=0.7),
+    ModelConfig("gemini-2.0-flash-lite", "google", default_temperature=0.7),
 ]
 
 

--- a/src/ipychat/providers/__init__.py
+++ b/src/ipychat/providers/__init__.py
@@ -6,11 +6,13 @@ from .anthropic import AnthropicProvider
 from .base import BaseProvider
 from .google import GoogleProvider
 from .openai import OpenAIProvider
+from .local import OllamaProvider
 
 PROVIDER_MAP = {
     "openai": OpenAIProvider,
     "anthropic": AnthropicProvider,
     "google": GoogleProvider,
+    "local": OllamaProvider,
 }
 
 

--- a/src/ipychat/providers/local.py
+++ b/src/ipychat/providers/local.py
@@ -12,7 +12,8 @@ class OllamaProvider(BaseProvider):
     def initialize_client(self) -> None:
         self.model = self.config["current"]["model"]
         self.client = ollama.Client()
-        # todo options like temperate ctx etc
+        self.temperature = self.config.get("local", {}).get("temperature", None)
+        self.num_ctx = self.config.get("local", {}).get("num_ctx", None)
 
     def stream_chat(
         self, system_prompt: str, user_content: str
@@ -21,6 +22,12 @@ class OllamaProvider(BaseProvider):
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_content},
         ]
+
+        options = {}
+        if self.temperature is not None:
+            options["temperature"] = self.temperature
+        if self.num_ctx is not None:
+            options["num_ctx"] = self.num_ctx
 
         try:
             response = self.client.chat(

--- a/src/ipychat/providers/local.py
+++ b/src/ipychat/providers/local.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+from typing import Generator
+
+import ollama 
+
+from .base import BaseProvider
+import contextlib
+
+
+class OllamaProvider(BaseProvider):
+    def initialize_client(self) -> None:
+        self.model = model=self.config["current"]["model"]
+        self.client = ollama.Client()
+        # todo options like temperate ctx etc
+    
+
+    def stream_chat(
+        self, system_prompt: str, user_content: str
+    ) -> Generator[str, None, None]:
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_content},
+        ]
+
+        try:
+            response = self.client.chat(
+                model = self.model,
+                messages=messages,
+                stream=True,
+            )
+
+            for chunk in response:
+                with contextlib.suppress(KeyError):
+                    yield chunk["message"]["content"]
+        except ollama.ResponseError as ex:
+            print(ex)
+            pass

--- a/src/ipychat/providers/local.py
+++ b/src/ipychat/providers/local.py
@@ -2,7 +2,7 @@
 
 from typing import Generator
 
-import ollama 
+import ollama
 
 from .base import BaseProvider
 import contextlib
@@ -10,10 +10,9 @@ import contextlib
 
 class OllamaProvider(BaseProvider):
     def initialize_client(self) -> None:
-        self.model = model=self.config["current"]["model"]
+        self.model = self.config["current"]["model"]
         self.client = ollama.Client()
         # todo options like temperate ctx etc
-    
 
     def stream_chat(
         self, system_prompt: str, user_content: str
@@ -25,7 +24,7 @@ class OllamaProvider(BaseProvider):
 
         try:
             response = self.client.chat(
-                model = self.model,
+                model=self.model,
                 messages=messages,
                 stream=True,
             )

--- a/src/ipychat/providers/local.py
+++ b/src/ipychat/providers/local.py
@@ -34,6 +34,7 @@ class OllamaProvider(BaseProvider):
                 model=self.model,
                 messages=messages,
                 stream=True,
+                options=options
             )
 
             for chunk in response:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,3 +36,8 @@ def mock_config_file(tmp_path: Path, mock_config):
     with open(config_file, "w") as f:
         toml.dump(mock_config, f)
     return config_file
+
+
+@pytest.fixture
+def mock_config_ollama():
+    return {"current": {"model": "llama3"}}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,15 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+from unittest.mock import patch, MagicMock
 
-from ipychat.models import get_current_model, get_model_by_name, get_models_by_provider
+from ipychat.models import (
+    get_current_model,
+    get_model_by_name,
+    get_models_by_provider,
+    get_ollama_models,
+    ModelConfig,
+)
 
 
 def test_get_model_by_name():
@@ -29,3 +36,24 @@ def test_get_current_model(mock_config, monkeypatch):
     model = get_current_model()
     assert model.name == "gpt-4o"
     assert model.provider == "openai"
+
+
+def test_get_ollama_models_success():
+    mock_model = MagicMock()
+    mock_model.model = "llama3"
+
+    with patch("ipychat.models.ollama.list") as mock_list:
+        mock_list.return_value.models = [mock_model]
+
+        result = get_ollama_models()
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0] == ModelConfig(name="llama3", provider="local")
+
+
+def test_get_ollama_models_exception():
+    with patch(
+        "ipychat.models.ollama.list", side_effect=Exception("Ollama not available")
+    ):
+        result = get_ollama_models()
+        assert result == []

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -179,11 +179,6 @@ def test_google_provider_missing_api_key(mock_config):
     )
 
 
-@pytest.fixture
-def mock_config_ollama():
-    return {"current": {"model": "llama3"}}
-
-
 def test_stream_chat_yields_content(mock_config_ollama):
     provider = OllamaProvider(mock_config_ollama)
     provider.model = "llama3"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -182,6 +182,8 @@ def test_google_provider_missing_api_key(mock_config):
 def test_stream_chat_yields_content(mock_config_ollama):
     provider = OllamaProvider(mock_config_ollama)
     provider.model = "llama3"
+    provider.temperature = None
+    provider.num_ctx = None
 
     # Mock client.chat stream
     mock_response = [
@@ -202,6 +204,8 @@ def test_stream_chat_yields_content(mock_config_ollama):
 def test_stream_chat_ignores_keyerror(mock_config_ollama):
     provider = OllamaProvider(mock_config_ollama)
     provider.model = "llama3"
+    provider.temperature = None
+    provider.num_ctx = None
 
     mock_response = [
         {"no_message": "oops"},  # Should be ignored due to KeyError

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
 import pytest
 
@@ -8,6 +8,7 @@ from ipychat.providers import get_provider
 from ipychat.providers.anthropic import AnthropicProvider
 from ipychat.providers.google import GoogleProvider
 from ipychat.providers.openai import OpenAIProvider
+from ipychat.providers.local import OllamaProvider
 
 
 def test_get_provider(mock_config):
@@ -176,3 +177,44 @@ def test_google_provider_missing_api_key(mock_config):
     mock_console.print.assert_called_once_with(
         "[red]Set [bold]GOOGLE_API_KEY[/bold] in your environment, or run [bold]ipychat config[/bold].[/red]"
     )
+
+
+@pytest.fixture
+def mock_config_ollama():
+    return {"current": {"model": "llama3"}}
+
+
+def test_stream_chat_yields_content(mock_config_ollama):
+    provider = OllamaProvider(mock_config_ollama)
+    provider.model = "llama3"
+
+    # Mock client.chat stream
+    mock_response = [
+        {"message": {"content": "Hello"}},
+        {"message": {"content": " world!"}},
+    ]
+
+    provider.client = MagicMock()
+    provider.client.chat.return_value = mock_response
+
+    gen = provider.stream_chat("You are a bot", "Say something")
+    result = list(gen)
+
+    assert result == ["Hello", " world!"]
+    provider.client.chat.assert_called_once()
+
+
+def test_stream_chat_ignores_keyerror(mock_config_ollama):
+    provider = OllamaProvider(mock_config_ollama)
+    provider.model = "llama3"
+
+    mock_response = [
+        {"no_message": "oops"},  # Should be ignored due to KeyError
+        {"message": {"content": "Recovered"}},
+    ]
+
+    provider.client = MagicMock()
+    provider.client.chat.return_value = mock_response
+
+    result = list(provider.stream_chat("You are a bot", "Continue"))
+    assert result == ["Recovered"]


### PR DESCRIPTION
**Exciting Update for ipychat! Chat with AI Locally!**

We're thrilled to announce a major new feature in the latest ipychat update: you can now use AI models running directly on your own computer!

Previously, ipychat connected to online AI services like GPT or Claude. Now, we've added support for **Ollama**, a popular tool that lets you run powerful AI models locally on your machine.

**What does this mean for you?**

*   **More Choice:** Easily switch between cloud-based AI and models running on your personal computer.
*   **Privacy:** Keep your conversations entirely on your own machine if you use a local model.
*   **Experimentation:** Try out a wide range of different open-source AI models available through Ollama.

If you already use Ollama to run AI models locally, ipychat will now be able to detect and use them.

Enjoy having even more ways to bring the power of AI into your coding sessions with ipychat!


![ipychat-local-chat-demo](https://github.com/user-attachments/assets/caeb90a5-b166-435e-8387-96d11c0657d0)
